### PR TITLE
Fix #13

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -166,6 +166,7 @@ module "hostsfile" {
 
 module "ssh_config" {
   source = "./modules/ssh_config"
+  deployment = var.deployment
   hosts = local.hosts
   keyfiles_path_prefix = var.keyfiles_path_prefix
   output_folder = "${var.output_instances_dir}"

--- a/terraform/modules/ansible_inventory/variables.tf
+++ b/terraform/modules/ansible_inventory/variables.tf
@@ -4,7 +4,6 @@
 variable deployment {
     type = string
     description = "Name of this deployment"
-    default = "soafee"
 }
 
 variable hosts {

--- a/terraform/modules/avp/main.tf
+++ b/terraform/modules/avp/main.tf
@@ -317,6 +317,7 @@ resource "aws_iam_instance_profile" "avp_builder"{
 
 module "instance_ec2" {
     source = "../instance_ec2"
+    deployment = var.deployment
 
     ec2_use_eips = var.ec2_use_eips
   

--- a/terraform/modules/instance_ec2/variables.tf
+++ b/terraform/modules/instance_ec2/variables.tf
@@ -4,7 +4,6 @@
 variable deployment {
     description = "Name of this deployment"
     type = string
-    default = "soafee"
 }
 
 variable "instances" {

--- a/terraform/modules/ssh_config/variables.tf
+++ b/terraform/modules/ssh_config/variables.tf
@@ -4,7 +4,6 @@
 variable "deployment" {
     type = string
     description = "Name of this deployment"
-    default = "soafee"
 }
 
 variable hosts {

--- a/terraform/modules/xronos_dashboard/main.tf
+++ b/terraform/modules/xronos_dashboard/main.tf
@@ -104,6 +104,7 @@ resource "aws_iam_instance_profile" "this"{
 
 module "instance_ec2" {
     source = "../instance_ec2"
+    deployment = var.deployment
 
     instances = [
       {


### PR DESCRIPTION
Terraform explicitly set 'deployment' variable. Previously was missed in ssh-config and resulted in an unexpected deployment being applied when a custom deployment name is used.